### PR TITLE
FIRE-250-취약점-cve-2021-32640-re-do-s-in-sec-websocket-protocol-header

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9700,8 +9700,8 @@ ws@^8.4.2:
   resolved "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz"
   integrity sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==
 
-ws@~6.1.0:
-  version "6.1.4"
+ws@~^6.2.2:
+  version "6.2.2"
   resolved "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz"
   integrity sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==
   dependencies:


### PR DESCRIPTION
CVE-2021-32640
A specially crafted value of the Sec-Websocket-Protocol header can be used to significantly slow down a ws server.
해결