### PR TITLE
FIRE-251-취약점-cve-2021-31597-improper-certificate-validation-in-xmlhttprequest-ssl

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9722,7 +9722,7 @@ xmlchars@^2.2.0:
   resolved "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmlhttprequest-ssl@~1.5.4:
+xmlhttprequest-ssl@^1.6.2:
   version "1.5.5"
   resolved "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz"
   integrity sha512-/bFPLUgJrfGUL10AIv4Y7/CUt6so9CLtB/oFxQSHseSDNNCdC6vwwKEqwLN6wNPBg9YWXAiMu8jkf6RPRS/75Q==


### PR DESCRIPTION
Improper Certificate Validation in xmlhttprequest-ssl
ssl 보안 이슈 해결